### PR TITLE
Add new table row in Google sheet docs for custom recommendations tit…

### DIFF
--- a/blocks/product-recommendations/product-recommendations.js
+++ b/blocks/product-recommendations/product-recommendations.js
@@ -93,8 +93,11 @@ function renderItems(block, recommendations) {
     dl.push({ event: 'recs-unit-impression-render', eventInfo: { ...dl.getState(), unitId: recommendation.unitId } });
   });
 
-  // Title
-  block.querySelector('h2').textContent = recommendation.storefrontLabel;
+  // Recommendations Section Title
+  const config = readBlockConfig(block);
+  const { title } = config;
+  const recommendationsTitle = title || recommendation.storefrontLabel;
+  block.querySelector('h2').textContent = recommendationsTitle;
 
   // Grid
   const grid = block.querySelector('.product-grid');


### PR DESCRIPTION
- Add the possibility to create a new row under the main row of the "Product Recommendations" table in our EDS document-based authoring content management system of choice, Google docs in our case.
- So that then we can split our new row in two cells:
-- in the left cell we need to write the word "title" - this is required.
-- In the right cell we can specify a custom title for this specific "Product Recommendations" element on that page.

Test URLs:
- Before: https://main--aem-eds-rnd--ivallogenes.hlx.live/
- After: https://feature-recommendations-custom-title--aem-eds-rnd--ivallogenes.hlx.live/
