### PR TITLE
POC: fetch and display cms block from remote Magento backend using GQL

### DIFF
--- a/api/graphql/useCmsBlock.js
+++ b/api/graphql/useCmsBlock.js
@@ -1,0 +1,38 @@
+export default async function useCmsBlock(block, blockId) {
+  const backEndUrl = 'https://master-7rqtwti-jriyveajv3sxu.eu-4.magentosite.cloud/graphql'; // Magento backend URL. TODO: get from config.
+  const graphqlQuery = `
+  {
+    cmsBlocks(identifiers: ["${blockId}"]) {
+      items {
+        content
+      }
+    }
+  }`;
+
+  function decodeHtml(encodedStr) {
+    const parser = document.createElement('textarea');
+    parser.innerHTML = encodedStr;
+    return parser.value;
+  }
+
+  fetch(backEndUrl, {
+      method: 'POST',
+      headers: {
+          'Content-Type': 'application/json'
+          // 'Authorization': 'Bearer <your_token>' // Auth token here.
+      },
+      body: JSON.stringify({ query: graphqlQuery })
+  })
+  .then(response => response.json())
+  .then(data => {
+      const items = data?.data?.cmsBlocks?.items;
+      if (items && items.length > 0) {
+          const decodedContent = decodeHtml(items[0].content);
+          block.innerHTML = decodedContent;
+      } else {
+          block.innerHTML = '<p>CMS block content not found.</p>';
+      }
+  })
+  .catch(error => console.error('GraphQL Error:', error));
+
+}

--- a/blocks/cms-block/cms-block.css
+++ b/blocks/cms-block/cms-block.css
@@ -1,0 +1,25 @@
+/* Since the cms block content is fetched from a remote Commerce backend, the cms block already has its html structure and styles defined
+in the Magento code base - styles are in the coupled theme and the html is in the cms block Page builder content. */
+/* However, only the cms block content is fetched and the styles are lost.
+So, we need to have the styles for a cms block in the EDS app code base.. which makes it a bit less flexible to work with. */
+
+.test-cms-block {
+    background-color: #f4f4f4;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    padding: 16px;
+
+    h1,
+    h2 {
+      letter-spacing: 0;
+      text-align: center;
+    }
+}
+
+/* @media screen and (min-width: 768px) {
+
+} */

--- a/blocks/cms-block/cms-block.js
+++ b/blocks/cms-block/cms-block.js
@@ -1,0 +1,31 @@
+import { readBlockConfig } from '../../scripts/aem.js';
+import useCmsBlock from '../../api/graphql/useCmsBlock.js';
+
+// POC for fetching CMS block content from remote Magento backend
+// using GraphQL. The blockId is passed as a config value to the block element from the document-authoring endpoint.
+// Of course this causes CORS error, so this also needs to be handled on the remote server.
+export default async function decorate(block) {
+  const config = readBlockConfig(block);
+  const { blockid } = config;
+
+  useCmsBlock(block, blockid);
+
+  try {
+    const h2 = document.createElement('h2');
+    h2.textContent = 'This cms block is fetched from remote Magento backend using GraphQL';
+    setTimeout(() => {
+      const cmsContent = document.querySelector('.test-cms-block');
+      cmsContent.append(h2);
+    }, 1500);
+  } catch (error) {
+    console.error('.test-cms-block not ready. ', error);
+  }
+
+  console.log('cms-block config: ', blockid);
+  console.log('cms-block : ', block);
+
+  //  [...block.children].forEach((row, i) => {
+  //   console.log('row: ' + row + ' Number of rows: ' + i)
+  //  });
+
+}


### PR DESCRIPTION
POC: fetch and display cms block from remote Magento backend using GraphQL.

**It works nicely, but CORS error needs to be handled on the remote server.

Test URLs:
- Before: https://main--aem-eds-rnd--ivallogeneshlx.live/
- After: https://feat-poc-fetch-cms-block--aem-eds-rnd--ivallogenes.hlx.page/
